### PR TITLE
Reload securities on mount if in failed state.  Remove failure messag…

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -3,9 +3,14 @@ import { fetchSecurities } from './securities'
 export const SET_BASE_CURRENCY = 'SET_BASE_CURRENCY'
 
 export const setBaseCurrency = currency => (dispatch, getState) => {
+  const originalCurrency = getState().user.baseCurrency
+
   dispatch({
     type: SET_BASE_CURRENCY,
     currency
   })
-  fetchSecurities()(dispatch, getState)
+
+  if (currency !== originalCurrency) {
+    fetchSecurities()(dispatch, getState)
+  }
 }

--- a/src/components/Prices.js
+++ b/src/components/Prices.js
@@ -12,7 +12,7 @@ class Prices extends React.Component {
     // fetch all prices if they haven't been updated in the past 2 minutes
     const updatedAt = this.props.updatedAt
     const diff = moment().diff(updatedAt, 'seconds')
-    if (!updatedAt || diff > 120) {
+    if (!updatedAt || diff > 120 || this.props.failureMessage) {
       this.props.fetchSecurities()
     }
   }
@@ -55,7 +55,7 @@ class Prices extends React.Component {
     }
     if (this.props.failureMessage) {
       return (
-        <div> {this.props.failureMessage} </div>
+        <div>Failed to fetch symbols:  {this.props.failureMessage} </div>
       )
     }
     const isMobile = this.props.isMobile

--- a/src/reducers/securities.js
+++ b/src/reducers/securities.js
@@ -34,7 +34,8 @@ export default (state = initialState, action) => {
         ...state,
         securities: action.response,
         isFetching: false,
-        updatedAt: now
+        updatedAt: now,
+        failureMessage: undefined
       }
 
     case SECURITIES_FETCH_FAILURE:
@@ -52,7 +53,8 @@ export default (state = initialState, action) => {
       return {
         ...state,
         securities,
-        updatedAt: now
+        updatedAt: now,
+        failureMessage: undefined
       }
 
     case SECURITIES_BALANCES_ONLY:


### PR DESCRIPTION
…e on successful update.  Don't refetch securities if same currency selected.

Side note: we should probably be storing the base currency of the securities in the securities slice and displaying that on the page rather than assuming that they're in the user's base currency. 