### PR TITLE
Selector idea

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,6 +9,7 @@ import SideNav from './SideNav'
 import 'semantic-ui-css/semantic.min.css'
 import { sidebarWidth, border } from '../lib/styles'
 import { mapDispatchToProps } from '../actions'
+import { getProps } from '../selector'
 
 class App extends React.Component {
   componentDidMount() {
@@ -70,9 +71,9 @@ const routeStyle = {
   minHeight: 300
 }
 
-const mapStateToProps = state => ({
-  uri: state.router.location.pathname,
-  isMobile: state.app.isMobile
-})
+const mapStateToProps = getProps(selector => ({
+  uri: selector.uri(),
+  isMobile: selector.isMobile()
+}))
 
 export default connect(mapStateToProps, mapDispatchToProps)(App)

--- a/src/selector.js
+++ b/src/selector.js
@@ -1,0 +1,6 @@
+const selector = state => ({
+  uri: () => state.router.location.pathname,
+  isMobile: () => state.app.isMobile
+})
+
+export const getProps = fn => state => fn(selector(state))


### PR DESCRIPTION
Currently, `state.app.isMobile` is repeated in 9 different components. If we restructure the state object, we'll have to change this path in 9 places.

My understanding is the purpose of selectors is to remove this repetition.

Here's a pretty simple solution. Thoughts?