### PR TITLE
Provide PricesRow component with same function on each render.  See #36

### DIFF
--- a/src/components/Prices.js
+++ b/src/components/Prices.js
@@ -11,6 +11,7 @@ class Prices extends React.PureComponent {
     this.state = {
       isBinanceSetupModalOpen: false
     }
+    this.openBinanceSetupModal = this.openBinanceSetupModal.bind(this)
   }
 
   openBinanceSetupModal(val) {
@@ -24,7 +25,7 @@ class Prices extends React.PureComponent {
         addManualTransaction={this.props.addManualTransaction}
         baseCurrency={this.props.baseCurrency}
         isMobile={this.props.isMobile}
-        openBinanceSetupModal={val => this.openBinanceSetupModal(val)}
+        openBinanceSetupModal={this.openBinanceSetupModal}
       />
     ))
   }


### PR DESCRIPTION
The fixes the lockup that I was seeing (although I don't have transactions going back too far at the moment).

`PricesRow` is a pure component.  It will only rerender if its props are deemed to have changed via a shallow comparison.  Using an inline arrow function for the callback means that a different function is passed every time the parent component rerenders, so the `PricesRow` component always rerenders in that case.  