### PR TITLE
Use bySymbol state slice instead of searching for symbols in `getSecurity`

### DIFF
--- a/src/lib/SocketClient.js
+++ b/src/lib/SocketClient.js
@@ -5,7 +5,7 @@ import { updateSecurity } from '../actions/securities'
 import * as schema from '../actions/schema'
 import { normalize } from 'normalizr'
 
-const enableStreamingPrices = false
+const enableStreamingPrices = true
 
 export default class SocketClient {
   start() {

--- a/src/selectors/securitiesSelectors.js
+++ b/src/selectors/securitiesSelectors.js
@@ -9,7 +9,7 @@ export const getBalancesOnlyFilter = state => state.securities.metadata.balances
 export const getQuery = state => state.app.filterSymbolsQuery
 
 export const getSecurity = (state, symbol) => {
-  return getSecurities(state).find(s => s.symbol === symbol)
+  return state.securities.bySymbol[symbol]
 }
 
 export const getStateSlices = createStructuredSelector({


### PR DESCRIPTION
This speeds things up for me enough to re-enable the streaming updates.

There are still some performance issues though, just not directly with the streaming updates. 