### PR TITLE
Allow routed URLs to be used on the heroku instance.

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,0 +1,12 @@
+{
+  "root": "build/",
+  "https_only": true,
+  "routes": {
+    "/**": "index.html"
+  },
+  "headers": {
+    "/**": {
+      "Strict-Transport-Security": "max-age=7776000"
+    }
+  }
+}


### PR DESCRIPTION
Allow routed URLs to be used on the heroku instance.
Also use HSTS on the heroku instance

I haven't actually tested this.   It's as per https://github.com/mars/create-react-app-buildpack#user-content-routing-clean-urls
