### PR TITLE
fixed mobile horizontal scroll issue on load without balance

### DIFF
--- a/src/components/NetWorthChart.js
+++ b/src/components/NetWorthChart.js
@@ -110,7 +110,7 @@ class NetWorthChart extends React.PureComponent {
             position: 'absolute',
             top: '47%',
             marginTop: '-0.25em',
-            marginLeft: '1em',
+            paddingLeft: '1em',
             width: '100%',
             textAlign: 'center',
             fontSize: 20,


### PR DESCRIPTION
replaced marginleft: '1em' with paddingLeft: '1em' on "Add Wallet" overlay to fix horizontal scroll issue