### PR TITLE
Fix trezor error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8-browsers
+      - image: circleci/node:lts-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/src/components/Trezor.js
+++ b/src/components/Trezor.js
@@ -35,6 +35,7 @@ function Trezor({
   const trezorSecurities = supportedSymbols
     .map(symbol => getSecurity(symbol))
     .sort((a, b) => a.name > b.name ? 1 : -1)
+    .filter(Boolean)
   const onClickDeleteWallet = event => {
     const id = event.target.parentNode.getAttribute('data-id')
     const name = event.target.parentNode.getAttribute('data-name')


### PR DESCRIPTION
For some reason `securities.bySymbol.DASH` is undefined and is causing an error so this prevents the error on the Trezor page.